### PR TITLE
support body options && ts type checking

### DIFF
--- a/copy-package.js
+++ b/copy-package.js
@@ -12,3 +12,4 @@ writeJsonSync('./dist/package.json', packageJson, { spaces: 2, EOL: '\n' });
 
 copySync('README.md', 'dist/README.md');
 copySync('LICENSE', 'dist/LICENSE');
+copySync('index.d.ts', 'dist/index.d.ts');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+import { Plugin } from 'rollup';
+
+export interface noopImportOptions {
+    body?: string;
+    exclude?: Array<string | RegExp> | string | RegExp | null
+    extensions?: Array<string>
+    include?: Array<string | RegExp> | string | RegExp | null
+}
+
+export default function noopImport(options: noopImportOptions): Plugin;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "rollup-plugin-ignore-import.js",
   "module": "rollup-plugin-ignore-import.es.js",
   "jsnext:main": "rollup-plugin-ignore-import.es.js",
+  "types": "index.d.ts",
   "scripts": {
     "build:copy:package": "node copy-package.js",
     "build": "rollup -c && npm run build:copy:package",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default function noopImport(options = {}) {
     transform(code, id) {
       if (!filter(id)) return;
 
-      const body = 'export default undefined;';
+      const body = (options.body || options.body === '') ? options.body : 'export default undefined;';
 
       return {
         code: body,


### PR DESCRIPTION
Broken by this case:
```js
[
  noopImport({
    extensions: [".css"]
  }),
  postcss(/* resolve saas */), // if there has some scss files
]
// (plugin postcss) CssSyntaxError: iconfont.css:1:1: Unknown word
```

So, It\`s useful by support body options with this case

```js
noopImport({
  extensions: [".css"],
  body: "/* [PLACEHOLDER] import iconfont file by youself */"
})
```
